### PR TITLE
selectivity-rails info

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ And in your code:
     var $ = require('jquery');
     require('selectivity');
 
+### Ruby on Rails
+
+Detailed information for `selectivity-rails`, including [Installation and usage](https://github.com/msx2/selectivity-rails#installation-and-usage) are provided in the [gem's repository](https://github.com/msx2/selectivity-rails).
+
 Browser Support
 ---------------
 


### PR DESCRIPTION
@arendjr Like I mentioned some time ago, I had in mind creating a gem to use Selectivity.js easily in Ruby on Rails.
So I created it - [msx2/selectivity-rails](https://github.com/msx2/selectivity-rails#installation-and-usage), and added some additional functionality that is described in README, without any modifications to sources from this repository (see `vendor`).

Hope you like it! And if you don't mind, I'd like to add this information to the README. :wink: 

The reason I asked about the release in #30 is that I was thinking of updating the gem with released versions of Selectivity.js instead of using it _directly_ from `master` branch, to keep consistency.