### PR TITLE
Fix createTokenItem behaviour

### DIFF
--- a/src/selectivity-multiple.js
+++ b/src/selectivity-multiple.js
@@ -337,6 +337,7 @@ var callSuper = Selectivity.inherits(MultipleSelectivity, {
         if (term && createTokenItem) {
             var item = createTokenItem(term);
             if (item) {
+                this.items.push(item);
                 this.add(item);
             }
         }
@@ -481,7 +482,7 @@ var callSuper = Selectivity.inherits(MultipleSelectivity, {
 
         if (event.added || event.removed) {
             if (this.dropdown) {
-                this.dropdown.showResults(this.filterResults(this.results), {
+                this.dropdown.showResults(this.filterResults(this.items), {
                     hasMore: this.dropdown.hasMore
                 });
             }


### PR DESCRIPTION
This PR is to fix the error `Cannot read property 'filter' of undefined` when using `createTokenItem`

![Selectivity bug](https://www.evernote.com/shard/s232/sh/e1b6ed73-1e42-4312-b11a-f204508c5418/5498c7316e873006/res/6a083a0b-255f-499c-8c18-6bb9d0fdd895/skitch.png?resizeSmall&width=832)

The error is cause by usage of `this.results` inside `_rerenderSelection` methods, which I think it should be `this.items`.

I also make a change to include the new token item into selectivity object `items` list.

Please help to review if it could cause any wrong behavior for the library.

Cheers.