### PR TITLE
Feature/do not overwrite original select

### DIFF
--- a/src/selectivity-traditional.js
+++ b/src/selectivity-traditional.js
@@ -62,7 +62,18 @@ function createSelectivityNextToSelectElement($el, options) {
 function bindTraditionalSelectEvents(selectivity) {
     var $el = selectivity.$el;
     $el.on('selectivity-selected', function(event) {
-        $el.prev('select').val(event.item.id).change();
+        var data = selectivity._data;
+        if (data instanceof Array) {
+            var ids = [event.item.id];
+
+            data.forEach(function(item) {
+                ids.push(item.id);
+            });
+
+            $el.prev('select').val(ids).change();
+        } else {
+            $el.prev('select').val(event.item.id).change();
+        }
     });
 }
 

--- a/src/selectivity-traditional.js
+++ b/src/selectivity-traditional.js
@@ -4,7 +4,7 @@ var $ = require('jquery');
 
 var Selectivity = require('./selectivity-base');
 
-function replaceSelectElement($el, options) {
+function createSelectivityNextToSelectElement($el, options) {
 
     var data = (options.multiple ? [] : null);
 
@@ -54,36 +54,15 @@ function replaceSelectElement($el, options) {
         'style': $el.attr('style'),
         'data-name': $el.attr('name')
     });
-    $el.replaceWith($div);
+    $div.insertAfter($el);
+    $el.hide();
     return $div;
 }
 
 function bindTraditionalSelectEvents(selectivity) {
-
     var $el = selectivity.$el;
-
-    $el.on('selectivity-init', function(event, mode) {
-        $el.append(selectivity.template('selectCompliance', {
-            mode: mode,
-            name: $el.attr('data-name')
-        })).removeAttr('data-name');
-    }).on('selectivity-init change', function() {
-        var data = selectivity._data;
-        var $select = $el.find('select');
-
-        if (data instanceof Array) {
-            $select.empty();
-
-            data.forEach(function(item) {
-                $select.append(selectivity.template('selectOptionCompliance', item));
-            });
-        } else {
-            if (data) {
-                $select.html(selectivity.template('selectOptionCompliance', data));
-            } else {
-                $select.empty();
-            }
-        }
+    $el.on('selectivity-selected', function(event) {
+        $el.prev('select').val(event.item.id).change();
     });
 }
 
@@ -101,7 +80,7 @@ Selectivity.OptionListeners.push(function(selectivity, options) {
             }, 1);
         }
 
-        selectivity.$el = replaceSelectElement($el, options);
+        selectivity.$el = createSelectivityNextToSelectElement($el, options);
         selectivity.$el[0].selectivity = selectivity;
 
         bindTraditionalSelectEvents(selectivity);

--- a/tests/unit/traditional.js
+++ b/tests/unit/traditional.js
@@ -57,3 +57,24 @@ exports.testInitializationMultiple = DomUtil.createDomTest(
         test.equal($options.last().val(), '4');
     }
 );
+
+exports.testSingleTraditionalChangeEvents = DomUtil.createDomTest(
+    ['single', 'templates', 'traditional'],
+    { indexResource: 'testcase-traditional.html' },
+    function(test, $input, $) {
+        var changeEvents = 0;
+        $input.selectivity({
+            query: function() {}
+        });
+
+        $input.on('change', function() {
+            changeEvents++;
+        });
+
+        $('.selectivity-single-select').trigger({type: 'selectivity-selected',
+            item: {id: 1, text: 'foo bar'}});
+
+        test.equal(changeEvents, 1);
+        test.equal($input.val(), "1");
+    }
+);

--- a/tests/unit/traditional.js
+++ b/tests/unit/traditional.js
@@ -75,6 +75,33 @@ exports.testSingleTraditionalChangeEvents = DomUtil.createDomTest(
             item: {id: 1, text: 'foo bar'}});
 
         test.equal(changeEvents, 1);
-        test.equal($input.val(), "1");
+        test.equal($input.val(), '1');
+    }
+);
+
+exports.testMultipeTraditionalChangeEvents = DomUtil.createDomTest(
+    ['multiple', 'templates', 'traditional'],
+    { indexResource: 'testcase-traditional-multiple.html' },
+    function(test, $input, $) {
+        var changeEvents = 0;
+        $input.selectivity({
+            query: function() {}
+        });
+
+        $input.on('change', function() {
+            changeEvents++;
+        });
+
+        $('.selectivity-multiple-input-container').trigger({type: 'selectivity-selected',
+            item: {id: 1, text: 'foo bar'}});
+
+        test.equal(changeEvents, 1);
+        test.deepEqual($input.val(), ['1', '3', '4']);
+
+        $('.selectivity-multiple-input-container').trigger({type: 'selectivity-selected',
+            item: {id: 2, text: 'foo bar'}});
+
+        test.equal(changeEvents, 2);
+        test.deepEqual($input.val(), ['1', '2', '3', '4']);
     }
 );


### PR DESCRIPTION
Overwriting the original select and hacking it back makes using Reactive Programming libraries difficult (Rx.js, Bacon.js). 

Better way is to preserve the original select as hidden and triggering a change event when the item is selected. 