### PR TITLE
enforce eslint no space in parens.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
         "no-unused-vars": 2,
         "semi": [2, "always"],
         "space-after-keywords": 2,
+        "space-in-parens": [2, "never"],
         "strict": [2, "global"],
         "quotes" : [2, "single"]
     },


### PR DESCRIPTION
After reading one of the pull request code styling hints, I suggest we enforce no space in parens rule. Let the automation do the style checking so more time can be spent on the actual review.