### PR TITLE
Feature/only one event on hover

### DIFF
--- a/src/selectivity-base.js
+++ b/src/selectivity-base.js
@@ -188,8 +188,8 @@ function Selectivity(options) {
         this.data(options.data || null, { triggerChange: false });
     }
 
-    this.$el.on('mouseenter', this._mouseover.bind(this));
-    this.$el.on('mouseleave', this._mouseout.bind(this));
+    this.$el.on('mouseenter', this._mouseenter.bind(this));
+    this.$el.on('mouseleave', this._mouseleave.bind(this));
     this.$el.on('selectivity-close', this._closed.bind(this));
     this.$el.on('selectivity-blur', this._blur.bind(this));
     this.$el.on('blur', this._blur.bind(this));
@@ -725,7 +725,7 @@ $.extend(Selectivity.prototype, EventDelegator.prototype, {
     /**
      * @private
      */
-    _mouseout: function() {
+    _mouseleave: function() {
 
         this.$el.toggleClass('hover', false);
     },
@@ -733,7 +733,7 @@ $.extend(Selectivity.prototype, EventDelegator.prototype, {
     /**
      * @private
      */
-    _mouseover: function() {
+    _mouseenter: function() {
 
         this.$el.toggleClass('hover', true);
     }

--- a/src/selectivity-base.js
+++ b/src/selectivity-base.js
@@ -188,7 +188,7 @@ function Selectivity(options) {
         this.data(options.data || null, { triggerChange: false });
     }
 
-    this.$el.on('mouseover', this._mouseover.bind(this));
+    this.$el.on('mouseenter', this._mouseover.bind(this));
     this.$el.on('mouseleave', this._mouseout.bind(this));
     this.$el.on('selectivity-close', this._closed.bind(this));
     this.$el.on('selectivity-blur', this._blur.bind(this));


### PR DESCRIPTION
mouseover on parent will execute every time when cursor goes to child node and back to parent.

Lets use mouseenter which executes only one event when the cursor is on parent element.
 