### PR TITLE
Use "s9y_" as prefix for Selectivity div ID when created from <select>

### DIFF
--- a/src/plugins/jquery/traditional.js
+++ b/src/plugins/jquery/traditional.js
@@ -55,7 +55,7 @@ function createSelectivityNextToSelectElement($el, options) {
     }
 
     var $div = $('<div>').attr({
-        'id': $el.attr('id'),
+        'id': 's9y_' + $el.attr('id'),
         'class': classes.join(' '),
         'style': $el.attr('style'),
         'data-name': $el.attr('name')

--- a/tests/unit/jquery/traditional.js
+++ b/tests/unit/jquery/traditional.js
@@ -18,6 +18,8 @@ TestUtil.createJQueryTest(
         var $options = $('select[name="my_select"] option[selected]');
         test.equal($options.length, 1);
         test.equal($options.first().val(), '3');
+
+        test.equal($('div.selectivity-input')[0].id, 's9y_selectivity-input');
     }
 );
 
@@ -71,6 +73,8 @@ TestUtil.createJQueryTest(
         test.equal($options.length, 2);
         test.equal($options.first().val(), '3');
         test.equal($options.last().val(), '4');
+
+        test.equal($('div.selectivity-input')[0].id, 's9y_selectivity-input');
     }
 );
 


### PR DESCRIPTION
No two elements in the DOM should have the same ID.
Fixes #146