### PR TITLE
extra check removed in componentWIllReceiveProps

### DIFF
--- a/src/apis/react.js
+++ b/src/apis/react.js
@@ -150,11 +150,11 @@ var SelectivityReact = React.createClass({
         var selectivity = this.selectivity;
 
         selectivity.setOptions(propsToOptions(nextProps));
-        if (nextProps.data !== this.props.data) {
+        if (nextProps.data) {
             selectivity.setData(nextProps.data, { triggerChange: false });
             selectivity.rerenderSelection();
         }
-        if (nextProps.value !== this.props.value) {
+        if (nextProps.value) {
             selectivity.setValue(nextProps.value, { triggerChange: false });
             selectivity.rerenderSelection();
         }


### PR DESCRIPTION
I just removed the **nextProps.data !== this.props.data** and **nextProps.value !== this.props.value** check as in my case the items for the element and value to be selected are coming differently.

So removing this check will not hamper the selectivity behaviour.Please review and let me know if this can be merged to master.