### PR TITLE
HTML5 validations support

### DIFF
--- a/src/inputs/single.js
+++ b/src/inputs/single.js
@@ -121,6 +121,7 @@ var callSuper = Selectivity.inherits(SingleInput, Selectivity, {
             removable: this.options.allowClear && !this.options.readOnly
         }, this._data) : { placeholder: this.options.placeholder });
 
+        this.el.querySelector('input').value = this._value;
         this.$('.selectivity-single-result-container').innerHTML = this.template(template, options);
     },
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -213,13 +213,17 @@ Selectivity.Templates = {
      * 'selectivity-single-result-container' which is the element containing the selected item or
      * the placeholder.
      */
-    singleSelectInput: (
-        '<div class="selectivity-single-select">' +
-            '<input type="text" class="selectivity-single-select-input">' +
-            '<div class="selectivity-single-result-container"></div>' +
-            '<i class="fa fa-sort-desc selectivity-caret"></i>' +
-        '</div>'
-    ),
+    singleSelectInput: function(options) {
+        return (
+            '<div class="selectivity-single-select">' +
+                '<input type="text" class="selectivity-single-select-input"' +
+                    (options.required ? ' required' : '') +
+                '>' +
+                '<div class="selectivity-single-result-container"></div>' +
+                '<i class="fa fa-sort-desc selectivity-caret"></i>' +
+            '</div>'
+        );
+    },
 
     /**
      * Renders the placeholder for single-select input boxes.

--- a/tests/unit/jquery/single.js
+++ b/tests/unit/jquery/single.js
@@ -79,6 +79,8 @@ TestUtil.createJQueryTest(
         test.deepEqual($input.selectivity('data'), { id: 'Amsterdam', text: 'Amsterdam' });
 
         test.deepEqual($input.selectivity('value'), 'Amsterdam');
+
+        test.equal($input[0].querySelector('input').value, 'Amsterdam');
     }
 );
 

--- a/tests/unit/jquery/single.js
+++ b/tests/unit/jquery/single.js
@@ -274,6 +274,18 @@ TestUtil.createJQueryTest(
 );
 
 TestUtil.createJQueryTest(
+    'jquery/single: test required option',
+    ['inputs/single', 'templates'],
+    function(test, $input) {
+        $input.selectivity({
+            required: true
+        });
+
+        test.equal($input[0].querySelector('input').required, true);
+    }
+);
+
+TestUtil.createJQueryTest(
     'jquery/single: test click and mouse over',
     ['inputs/single', 'dropdown', 'templates'],
     { async: true },

--- a/tests/unit/react/single.js
+++ b/tests/unit/react/single.js
@@ -94,9 +94,13 @@ TestUtil.createReactTest(
     ['inputs/single', 'templates'],
     { defaultValue: 'Amsterdam', items: ['Amsterdam', 'Antwerp', 'Athens'] },
     function(SelectivityReact, test, ref) {
+        var el = ref._reactInternalInstance._hostContainerInfo._node;
+
         test.deepEqual(ref.getData(), { id: 'Amsterdam', text: 'Amsterdam' });
 
         test.deepEqual(ref.getValue(), 'Amsterdam');
+
+        test.equal(el.querySelector('input').value, 'Amsterdam');
     }
 );
 

--- a/tests/unit/react/single.js
+++ b/tests/unit/react/single.js
@@ -304,6 +304,17 @@ TestUtil.createReactTest(
 );
 
 TestUtil.createReactTest(
+    'react/single: test required option',
+    ['inputs/single', 'templates'],
+    { required: true },
+    function(SelectivityReact, test, ref) {
+        var el = ref._reactInternalInstance._hostContainerInfo._node;
+
+        test.equal(el.querySelector('input').required, true);
+    }
+);
+
+TestUtil.createReactTest(
     'react/single: test click and mouse over',
     ['inputs/single', 'dropdown', 'templates'],
     { async: true, defaultValue: 'Amsterdam' },

--- a/tests/unit/react/single.js
+++ b/tests/unit/react/single.js
@@ -93,14 +93,12 @@ TestUtil.createReactTest(
     'react/single: test initial value',
     ['inputs/single', 'templates'],
     { defaultValue: 'Amsterdam', items: ['Amsterdam', 'Antwerp', 'Athens'] },
-    function(SelectivityReact, test, ref) {
-        var el = ref._reactInternalInstance._hostContainerInfo._node;
-
+    function(SelectivityReact, test, ref, container, $) {
         test.deepEqual(ref.getData(), { id: 'Amsterdam', text: 'Amsterdam' });
 
         test.deepEqual(ref.getValue(), 'Amsterdam');
 
-        test.equal(el.querySelector('input').value, 'Amsterdam');
+        test.equal($('input')[0].value, 'Amsterdam');
     }
 );
 
@@ -311,10 +309,8 @@ TestUtil.createReactTest(
     'react/single: test required option',
     ['inputs/single', 'templates'],
     { required: true },
-    function(SelectivityReact, test, ref) {
-        var el = ref._reactInternalInstance._hostContainerInfo._node;
-
-        test.equal(el.querySelector('input').required, true);
+    function(SelectivityReact, test, ref, container, $) {
+        test.equal($('input')[0].required, true);
     }
 );
 


### PR DESCRIPTION
These are simple changes. It's about set two attributes into `input` element. The first one is `required`, that will tell browser to check if `input` was filled out; and the second one is `value`, that will avoid the validation error when an option is selected.

More details of html5 validations: https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation